### PR TITLE
pkg-config: Avoid duplication of linker flags

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3907,9 +3907,9 @@ AC_HELP_STRING([--enable-render-d3d], [enable the Direct3D render driver [[defau
         ;;
 	aarch64-none-elf*)
         ARCH=switch
-        SDL_CFLAGS="$SDL_CFLAGS -isystem ${DEVKITPRO}/libnx/include -I${DEVKITPRO}/portlibs/switch/include -D__SWITCH__=1 -march=armv8-a -mtune=cortex-a57 -mtp=soft -ftls-model=local-exec"
-        SDL_LIBS="-march=armv8-a  -fPIC -specs=${DEVKITPRO}/libnx/switch.specs -L${DEVKITPRO}/portlibs/switch/lib $SDL_LIBS  -L${DEVKITPRO}/libnx/lib -lnx"
+        SDL_CFLAGS="$SDL_CFLAGS -isystem ${DEVKITPRO}/libnx/include -I${DEVKITPRO}/portlibs/switch/include -D__SWITCH__ -march=armv8-a -mtune=cortex-a57 -mtp=soft -ftls-model=local-exec"
         EXTRA_CFLAGS="$EXTRA_CFLAGS -g -O2 $SDL_CFLAGS -fPIC"
+        EXTRA_LDFLAGS="-march=armv8-a -fPIE -specs=${DEVKITPRO}/libnx/switch.specs -L${DEVKITPRO}/libnx/lib -lnx"
         CheckDeclarationAfterStatement
 
         # Set up files for the video library


### PR DESCRIPTION
I am not entirely sure we should add all that `libnx` stuff unconditionally anyway.
This at least makes it not duplicate itself in the `pkg-config --libs sdl2` output.