### PR TITLE
switch: fix window cropping (glViewport, ...)

### DIFF
--- a/src/video/switch/SDL_switchopengles.c
+++ b/src/video/switch/SDL_switchopengles.c
@@ -44,13 +44,6 @@ SWITCH_GLES_LoadLibrary(_THIS, const char *path)
     return SDL_EGL_LoadLibrary(_this, path, EGL_DEFAULT_DISPLAY, 0);
 }
 
-void
-SWITCH_GLES_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h)
-{
-    *w = 1920;
-    *h = 1080;
-}
-
 SDL_EGL_CreateContext_impl(SWITCH)
 SDL_EGL_MakeCurrent_impl(SWITCH)
 SDL_EGL_SwapWindow_impl(SWITCH)

--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -97,7 +97,6 @@ SWITCH_CreateDevice(int devindex)
     device->GL_SwapWindow = SWITCH_GLES_SwapWindow;
     device->GL_DeleteContext = SWITCH_GLES_DeleteContext;
     device->GL_DefaultProfileConfig = SWITCH_GLES_DefaultProfileConfig;
-    device->GL_GetDrawableSize = SWITCH_GLES_GetDrawableSize;
 
     device->PumpEvents = SWITCH_PumpEvents;
 
@@ -220,7 +219,7 @@ SWITCH_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
         data = (SDL_WindowData *) SDL_GetFocusWindow()->driverdata;
     }
 
-    rc = nwindowSetCrop(&data->nWindow, 0, 0, mode->w, mode->h);
+    rc = nwindowSetCrop(&data->nWindow, 0, 1080 - mode->h, mode->w, 1080);
     if (rc) {
         return SDL_SetError("Could not set NWindow crop: 0x%x", rc);
     }
@@ -266,7 +265,7 @@ SWITCH_CreateWindow(_THIS, SDL_Window *window)
         return SDL_SetError("Could not set NWindow dimensions: 0x%x", rc);
     }
 
-    rc = nwindowSetCrop(&wdata->nWindow, 0, 0, window->w, window->h);
+    rc = nwindowSetCrop(&wdata->nWindow, 0, 1080 - window->h, window->w, 1080);
     if (R_FAILED(rc)) {
         nwindowClose(&wdata->nWindow);
         viCloseLayer(&wdata->viLayer);
@@ -328,7 +327,7 @@ void
 SWITCH_SetWindowSize(_THIS, SDL_Window *window)
 {
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
-    nwindowSetCrop(&data->nWindow, 0, 0, window->w, window->h);
+    nwindowSetCrop(&data->nWindow, 0, 1080 - window->h, window->w, 1080);
 }
 void
 SWITCH_ShowWindow(_THIS, SDL_Window *window)


### PR DESCRIPTION
However, there's still a minor difference with linux sdl2/gl when drawing without a renderer: you still have to set your viewport manually at least once when creating a 720p window ("glViewport(0, 0, 1280, 720)"), this needs to be investigated. When drawing with an sdl2 renderer, all is working as excepted (same SDL_SetWindowSize behavior as on linux sdl2/gl)