### PR TITLE
Bugfix in SDL_ThreadID()

### DIFF
--- a/src/thread/n3ds/SDL_systhread.c
+++ b/src/thread/n3ds/SDL_systhread.c
@@ -73,10 +73,12 @@ Uint32 SDL_ThreadID(void)
 {
 	//Incompatible with SDL API, this function will NOT return
 	//a valid thread ID when called from the main thread.
+	u32 threadID=0;
 	Thread current = threadGetCurrent();
-	Handle handle = threadGetHandle(current);
-	u32 threadID;
-	svcGetThreadId(&threadID, handle);
+	if (current) {
+		Handle handle = threadGetHandle(current);
+		svcGetThreadId(&threadID, handle);
+	}
 
 	return threadID;
 }


### PR DESCRIPTION
Without these changes, SDL_ThreadID() will return an undefined (random) result when called from the main thread. This will mess up locking/unlocking of mutexes and will - on occasions - cause SDL_PollEvent/SDL_PeepEvents to freeze when called from the main thread. This bug caused me a lot of headache and took me days to track down ...