### PR TITLE
Fix compilation of cpuinfo module

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -769,7 +769,7 @@ SDL_GetSystemRAM(void)
 #endif
 #ifdef HAVE_SYSCTLBYNAME
         if (SDL_SystemRAM <= 0) {
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__SWITCH__)
 #ifdef HW_REALMEM
             int mib[2] = {CTL_HW, HW_REALMEM};
 #else


### PR DESCRIPTION
This module is required in order for CPU detection to succeed so that the proper audio conversion function can be used.  
When configuring, `--enable-cpuinfo` needs to be used instead of `--disable-cpuinfo`.