### PR TITLE
switch: fix crash on exit

### DIFF
--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -152,6 +152,10 @@ SWITCH_VideoInit(_THIS)
 void
 SWITCH_VideoQuit(_THIS)
 {
+    if (_this->gl_config.driver_loaded) {
+        SDL_GL_UnloadLibrary();
+    }
+
     // exit touch
     SWITCH_QuitTouch();
     //exit keyboard


### PR DESCRIPTION
Since commit 937d0c8dedc, SDL_EGL_LoadLibraryOnly function set _this->gl_config.driver_loaded to 1.

Calling SDL_GL_UnloadLibrary during SWITCH_VideoQuit process fixes the problem