### PR TITLE
switch: fix window size handling.

### DIFF
--- a/src/video/switch/SDL_switchopengles.c
+++ b/src/video/switch/SDL_switchopengles.c
@@ -44,13 +44,6 @@ SWITCH_GLES_LoadLibrary(_THIS, const char *path)
     return SDL_EGL_LoadLibrary(_this, path, EGL_DEFAULT_DISPLAY, 0);
 }
 
-void
-SWITCH_GLES_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h)
-{
-    *w = 1920;
-    *h = 1080;
-}
-
 SDL_EGL_CreateContext_impl(SWITCH)
 SDL_EGL_MakeCurrent_impl(SWITCH)
 SDL_EGL_SwapWindow_impl(SWITCH)

--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -103,7 +103,6 @@ SWITCH_CreateDevice(int devindex)
     device->GL_SwapWindow = SWITCH_GLES_SwapWindow;
     device->GL_DeleteContext = SWITCH_GLES_DeleteContext;
     device->GL_DefaultProfileConfig = SWITCH_GLES_DefaultProfileConfig;
-    device->GL_GetDrawableSize = SWITCH_GLES_GetDrawableSize;
 
     device->PumpEvents = SWITCH_PumpEvents;
 
@@ -185,7 +184,7 @@ int
 SWITCH_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
     NWindow *nWindow = nwindowGetDefault();
-    Result rc = nwindowSetCrop(nWindow, 0, 0, mode->w, mode->h);
+    Result rc = nwindowSetDimensions(nWindow, mode->w, mode->h);
     if (rc) {
         return SDL_SetError("Could not set NWindow crop: 0x%x", rc);
     }
@@ -215,14 +214,9 @@ SWITCH_CreateWindow(_THIS, SDL_Window *window)
 
     nWindow = nwindowGetDefault();
 
-    rc = nwindowSetDimensions(nWindow, 1920, 1080);
+    rc = nwindowSetDimensions(nWindow, window->w, window->h);
     if (R_FAILED(rc)) {
         return SDL_SetError("Could not set NWindow dimensions: 0x%x", rc);
-    }
-
-    rc = nwindowSetCrop(nWindow, 0, 0, window->w, window->h);
-    if (R_FAILED(rc)) {
-        return SDL_SetError("Could not set NWindow crop: 0x%x", rc);
     }
 
     window_data->egl_surface = SDL_EGL_CreateSurface(_this, nWindow);
@@ -282,7 +276,7 @@ void
 SWITCH_SetWindowSize(_THIS, SDL_Window *window)
 {
     NWindow *nWindow = nwindowGetDefault();
-    nwindowSetCrop(nWindow, 0, 0, window->w, window->h);
+    nwindowSetDimensions(nWindow, window->w, window->h);
 }
 void
 SWITCH_ShowWindow(_THIS, SDL_Window *window)

--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -183,10 +183,16 @@ SWITCH_GetDisplayModes(_THIS, SDL_VideoDisplay *display)
 int
 SWITCH_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
+    SDL_WindowData *data = (SDL_WindowData *) SDL_GetFocusWindow()->driverdata;
+    SDL_GLContext ctx = SDL_GL_GetCurrentContext();
     NWindow *nWindow = nwindowGetDefault();
-    Result rc = nwindowSetDimensions(nWindow, mode->w, mode->h);
-    if (rc) {
-        return SDL_SetError("Could not set NWindow crop: 0x%x", rc);
+
+    if (data != NULL && data->egl_surface != EGL_NO_SURFACE) {
+        SDL_EGL_MakeCurrent(_this, NULL, NULL);
+        SDL_EGL_DestroySurface(_this, data->egl_surface);
+        nwindowSetDimensions(nWindow, mode->w, mode->h);
+        data->egl_surface = SDL_EGL_CreateSurface(_this, nWindow);
+        SDL_EGL_MakeCurrent(_this, data->egl_surface, ctx);
     }
 
     return 0;
@@ -244,6 +250,7 @@ SWITCH_DestroyWindow(_THIS, SDL_Window *window)
     if (window == switch_window) {
         if (data != NULL) {
             if (data->egl_surface != EGL_NO_SURFACE) {
+                SDL_EGL_MakeCurrent(_this, NULL, NULL);
                 SDL_EGL_DestroySurface(_this, data->egl_surface);
             }
             if(window->driverdata != NULL) {
@@ -275,8 +282,20 @@ SWITCH_SetWindowPosition(_THIS, SDL_Window *window)
 void
 SWITCH_SetWindowSize(_THIS, SDL_Window *window)
 {
+    u32 w = 0, h = 0;
+    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+    SDL_GLContext ctx = SDL_GL_GetCurrentContext();
     NWindow *nWindow = nwindowGetDefault();
-    nwindowSetDimensions(nWindow, window->w, window->h);
+
+    if(window->w != w || window->h != h) {
+        if (data != NULL && data->egl_surface != EGL_NO_SURFACE) {
+            SDL_EGL_MakeCurrent(_this, NULL, NULL);
+            SDL_EGL_DestroySurface(_this, data->egl_surface);
+            nwindowSetDimensions(nWindow, window->w, window->h);
+            data->egl_surface = SDL_EGL_CreateSurface(_this, nWindow);
+            SDL_EGL_MakeCurrent(_this, data->egl_surface, ctx);
+        }
+    }
 }
 void
 SWITCH_ShowWindow(_THIS, SDL_Window *window)


### PR DESCRIPTION
The previous behavior was to use nwindowSetCrop to change the "viewport" so a 720p window would be rendered to "fit screen" in a 1080p display mode (or a 1080p window to "fit screen" on a 720p display mode), while it's not the behavior on window (the window should just be smaller, or larger, than "screen" size).