### PR TITLE
Move default setting of conversion of touch to mouse events to SDL_mouse.c

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -100,8 +100,14 @@ static void SDLCALL
 SDL_TouchMouseEventsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
+    SDL_bool default_value;
 
-    mouse->touch_mouse_events = SDL_GetStringBoolean(hint, SDL_TRUE);
+#if defined(__SWITCH__)
+    default_value = SDL_FALSE;
+#else
+    default_value = SDL_TRUE;
+#endif
+    mouse->touch_mouse_events = SDL_GetStringBoolean(hint, default_value);
 }
 
 static void SDLCALL

--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -51,7 +51,6 @@ void
 SWITCH_InitTouch(void)
 {
     SDL_AddTouch((SDL_TouchID) 0, SDL_TOUCH_DEVICE_DIRECT, "Switch");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 }
 
 void


### PR DESCRIPTION
This will allow applications to set this hint for when conversion of touch to mouse events are needed.