### PR TITLE
Do not set SDL_HINT_TOUCH_MOUSE_EVENTS

### DIFF
--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -51,7 +51,6 @@ void
 SWITCH_InitTouch(void)
 {
     SDL_AddTouch((SDL_TouchID) 0, SDL_TOUCH_DEVICE_DIRECT, "Switch");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 }
 
 void


### PR DESCRIPTION
Setting this hint will make applications unable to set this hint.  
Some applications depend on touch events being converted to mouse events.  