### PR TITLE
Set SDL_HINT_TOUCH_MOUSE_EVENTS with priority SDL_HINT_DEFAULT

### DIFF
--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -51,7 +51,7 @@ void
 SWITCH_InitTouch(void)
 {
     SDL_AddTouch((SDL_TouchID) 0, SDL_TOUCH_DEVICE_DIRECT, "Switch");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+    SDL_SetHintWithPriority(SDL_HINT_TOUCH_MOUSE_EVENTS, "0", SDL_HINT_DEFAULT);
 }
 
 void


### PR DESCRIPTION
This will ensure that the hint won't be overwritten if the hint is set before SDL is initialized