### PR TITLE
3ds-SDL: multiple fixes

### DIFF
--- a/src/joystick/n3ds/SDL_sysjoystick.c
+++ b/src/joystick/n3ds/SDL_sysjoystick.c
@@ -29,7 +29,7 @@ const char *SDL_SYS_JoystickName (int index) {
 }
 
 int SDL_SYS_JoystickOpen(SDL_Joystick *joystick) {
-	joystick->nbuttons = 8;
+	joystick->nbuttons = 14;
 	joystick->nhats = 0;
 	joystick->nballs = 0;
 	joystick->naxes = 2;
@@ -74,13 +74,31 @@ void SDL_SYS_JoystickUpdate (SDL_Joystick *joystick) {
 		SDL_PrivateJoystickButton (joystick, 7, SDL_PRESSED);
 	}
 	if ((key_press & KEY_START)) {
-		SDL_PrivateJoystickButton (joystick, 8, SDL_PRESSED);
+		SDL_PrivateJoystickButton (joystick, 0, SDL_PRESSED);
 	}
 	if ((key_press & KEY_L)) {
 		SDL_PrivateJoystickButton (joystick, 5, SDL_PRESSED);
 	}
-	if ((key_press&KEY_R)) {
-		SDL_PrivateJoystickButton(joystick, 6,SDL_PRESSED);
+	if ((key_press & KEY_R)) {
+		SDL_PrivateJoystickButton (joystick, 6, SDL_PRESSED);
+	}
+	if ((key_press & KEY_DDOWN)) {
+		SDL_PrivateJoystickButton (joystick, 8, SDL_PRESSED);
+	}
+	if ((key_press & KEY_DLEFT)) {
+		SDL_PrivateJoystickButton (joystick, 9, SDL_PRESSED);
+	}
+	if ((key_press & KEY_DUP)) {
+		SDL_PrivateJoystickButton (joystick, 10, SDL_PRESSED);
+	}
+	if ((key_press & KEY_DRIGHT)) {
+		SDL_PrivateJoystickButton (joystick, 11, SDL_PRESSED);
+	}
+	if ((key_press & KEY_ZL)) {
+		SDL_PrivateJoystickButton (joystick, 12, SDL_PRESSED);
+	}
+	if ((key_press & KEY_ZR)) {
+		SDL_PrivateJoystickButton (joystick, 13, SDL_PRESSED);
 	}
 
 	key_release = hidKeysUp ();
@@ -100,13 +118,31 @@ void SDL_SYS_JoystickUpdate (SDL_Joystick *joystick) {
 		SDL_PrivateJoystickButton (joystick, 7, SDL_RELEASED);
 	}
 	if ((key_release & KEY_START)) {
-		SDL_PrivateJoystickButton (joystick, 8, SDL_RELEASED);
+		SDL_PrivateJoystickButton (joystick, 0, SDL_RELEASED);
 	}
 	if ((key_release & KEY_L)) {
 		SDL_PrivateJoystickButton (joystick, 5, SDL_RELEASED);
 	}
 	if ((key_release & KEY_R)) {
 		SDL_PrivateJoystickButton (joystick, 6, SDL_RELEASED);
+	}
+	if ((key_release & KEY_DDOWN)) {
+		SDL_PrivateJoystickButton (joystick, 8, SDL_RELEASED);
+	}
+	if ((key_release & KEY_DLEFT)) {
+		SDL_PrivateJoystickButton (joystick, 9, SDL_RELEASED);
+	}
+	if ((key_release & KEY_DUP)) {
+		SDL_PrivateJoystickButton (joystick, 10, SDL_RELEASED);
+	}
+	if ((key_release & KEY_DRIGHT)) {
+		SDL_PrivateJoystickButton (joystick, 11, SDL_RELEASED);
+	}
+	if ((key_release & KEY_ZL)) {
+		SDL_PrivateJoystickButton (joystick, 12, SDL_RELEASED);
+	}
+	if ((key_release & KEY_ZR)) {
+		SDL_PrivateJoystickButton (joystick, 13, SDL_RELEASED);
 	}
 }
 

--- a/src/video/n3ds/SDL_n3dsevents.c
+++ b/src/video/n3ds/SDL_n3dsevents.c
@@ -65,9 +65,6 @@ void task_exit() {
     aptUnhook(&cookie);
 }
 
-static SDLKey keymap[N3DS_NUMKEYS];
-char keymem[N3DS_NUMKEYS];
-
 void N3DS_PumpEvents(_THIS)
 {
 	svcSleepThread(100000); // 0.1 ms
@@ -82,27 +79,6 @@ void N3DS_PumpEvents(_THIS)
 	} 
 	
 	hidScanInput();
-
-	int i;
-	SDL_keysym keysym;
-	keysym.mod = KMOD_NONE;
-
-	for (i = 0; i < N3DS_NUMKEYS; i++) {
-		keysym.scancode = i;
-		keysym.sym = keymap[i];
-
-		if (hidKeysHeld() & (1 << i) && !keymem[i]) {
-			keymem[i] = 1;
-
-			SDL_PrivateKeyboard (SDL_PRESSED, &keysym);
-		}
-
-		if (!(hidKeysHeld() & (1 << i)) && keymem[i]) {
-			keymem[i] = 0;
-
-			SDL_PrivateKeyboard (SDL_RELEASED, &keysym);
-		}
-	}
 
 	if (hidKeysHeld() & KEY_TOUCH) {
 		touchPosition touch;
@@ -134,53 +110,7 @@ void N3DS_PumpEvents(_THIS)
 
 void N3DS_InitOSKeymap(_THIS)
 {
-	SDL_memset(keymem,1,N3DS_NUMKEYS);
-	keymap[0]=SDLK_a; //KEY_A
-	keymap[1]=SDLK_b; // KEY_B
-	keymap[2]=SDLK_ESCAPE; //KEY_SELECT
-	keymap[3]=SDLK_RETURN; //KEY_START
-	keymap[4]=SDLK_RIGHT; //KEY_RIGHT
-	keymap[5]=SDLK_LEFT; //KEY_LEFT
-	keymap[6]=SDLK_UP; // KEY_UP
-	keymap[7]=SDLK_DOWN; //KEY_DOWN
-	keymap[8]=SDLK_r; //KEY_R
-	keymap[9]=SDLK_l; //KEY_L
-	keymap[10]=SDLK_x; //KEY_X 
-	keymap[11]=SDLK_y; //KEY_Y 
-	keymap[12]=SDLK_UNKNOWN; 
-	keymap[13]=SDLK_UNKNOWN; 
-	keymap[14]=SDLK_LSHIFT;  //KEY_ZL 
-	keymap[15]=SDLK_RSHIFT;  //KEY_ZR
-	keymap[16]=SDLK_UNKNOWN; 
-	keymap[17]=SDLK_UNKNOWN; 
-	keymap[18]=SDLK_UNKNOWN; 
-	keymap[19]=SDLK_UNKNOWN; 
-	keymap[20]=SDLK_UNKNOWN; 
-	keymap[21]=SDLK_UNKNOWN; 
-	keymap[22]=SDLK_UNKNOWN; 
-	keymap[23]=SDLK_UNKNOWN; 
-	keymap[24]=SDLK_UNKNOWN; 
-	keymap[25]=SDLK_UNKNOWN; 
-	keymap[26]=SDLK_UNKNOWN; 
-	keymap[27]=SDLK_UNKNOWN; 
-	keymap[28]=SDLK_UNKNOWN; 
-	keymap[29]=SDLK_UNKNOWN; 
-	keymap[30]=SDLK_UNKNOWN; 
-	keymap[31]=SDLK_UNKNOWN; 
-
-// init the key state
-	int i;
-	hidScanInput();
-	for (i = 0; i < N3DS_NUMKEYS; i++)
-		keymem[i] = (hidKeysHeld() & (1 << i))?1:0;
-}
-
-void SDL_N3DSKeyBind(unsigned int hidkey, SDLKey key) {
-	int i,pos;
-	for (i = 0; i < N3DS_NUMKEYS; i++) {
-		pos= 1<<i;
-		if(hidkey&pos) keymap[i]=key;
-	}
+	// Do nothing
 }
 
 

--- a/src/video/n3ds/SDL_n3dsevents_c.h
+++ b/src/video/n3ds/SDL_n3dsevents_c.h
@@ -24,7 +24,6 @@
 
 #include "SDL_n3dsvideo.h"
 
-#define N3DS_NUMKEYS 32
 /* Variables and functions exported by SDL_sysevents.c to other parts 
    of the native video subsystem (SDL_sysvideo.c)
 */

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -611,7 +611,10 @@ static int N3DS_SetColors(_THIS, int firstcolor, int ncolors, SDL_Color *colors)
 	Uint32* palette = this->hidden->palette;
 
 	for (i = firstcolor; i < firstcolor + ncolors; i++)
-		palette[i] = N3DS_MAP_RGB(colors[i].r, colors[i].g, colors[i].b);
+	{
+		int colorIndex = i - firstcolor;
+		palette[i] = N3DS_MAP_RGB(colors[colorIndex].r, colors[colorIndex].g, colors[colorIndex].b);
+	}
 
 	return(1);
 }


### PR DESCRIPTION
This PR fixes a bunch of bugs that I found while porting https://github.com/sergiou87/open-supaplex to 3DS:
- The Start button didn't work at all. The number of buttons of SDL_Joystick was set to 8... but the indices used for the buttons were 1-8, and Start had the 8. Changed Start to use 0 instead.
- It also adds support for the D-pad buttons and the ZL/ZR buttons (New 3DS only). Before this, the only way to detect the D-pad buttons was through the keyboard API…
- Another change related to the previous one: stop mapping 3DS buttons into keyboard keys. Seems like that was an ad-hoc solution for the specific game (OpenTyrian) that was ported using this SDL port, instead of mapping the buttons on the game code. But this is just a theory 😛 
- It also fixes the `SetColors` function for 3DS, which assumed the input `colors` array was a 256 colors array, but it's not. That parameter has `ncolors` inside.