### PR TITLE
3ds-SDL: Remove unused function SDL_N3DSKeyBind declaration

### DIFF
--- a/include/SDL_keyboard.h
+++ b/include/SDL_keyboard.h
@@ -125,10 +125,6 @@ extern DECLSPEC void SDLCALL SDL_SetModState(SDLMod modstate);
  */
 extern DECLSPEC char * SDLCALL SDL_GetKeyName(SDLKey key);
 
-#ifdef _3DS
-void SDL_N3DSKeyBind(unsigned int hidkey, SDLKey key);
-#endif
-
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Sorry, I forgot to get rid of this declaration in #57

It doesn't cause any issues because it's never used. But I guess it's better if I leave everything cleaned up 😄 

Thanks @carstene1ns for the heads up!