### PR TITLE
3DS: Add SDL_SYNCDRAW flag for frame sync

### DIFF
--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -151,6 +151,7 @@ typedef struct SDL_Surface {
 #define SDL_FITHEIGHT	0x00800000	/**> Render a resized surface to fit systen screen height */
 #define SDL_CONSOLETOP	0x00040000	/**> Enale console output on Top screen */
 #define SDL_CONSOLEBOTTOM	0x00080000	/**> Enale console output on Bottom screen */
+#define SDL_SYNCDRAW	0x00020000	/**> Perform frame sync before checking the GPU status when drawing */
 #endif
 /*@}*/
 

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -503,8 +503,7 @@ static void videoThread(void* data)
 			break;
 
 		if(gspHasGpuRight()) {
-//			if (C3D_FrameBegin(C3D_FRAME_SYNCDRAW)){
-			if (C3D_FrameBegin(C3D_FRAME_NONBLOCK)){
+			if (C3D_FrameBegin(this->hidden->flags & SDL_SYNCDRAW ? C3D_FRAME_SYNCDRAW : C3D_FRAME_NONBLOCK)){
 				if (this->hidden->screens & SDL_TOPSCR) {
 					C3D_RenderTargetClear(VideoSurface1, C3D_CLEAR_ALL, RenderClearColor, 0);
 					C3D_FrameDrawOn(VideoSurface1);
@@ -547,7 +546,9 @@ static void drawBuffers(_THIS)
 
 		C3D_TexEnvFunc(env, C3D_Both, GPU_REPLACE);
 
-		gspWaitForVBlank();
+		if (!(this->hidden->flags & SDL_SYNCDRAW))
+			gspWaitForVBlank();
+
 		LightEvent_Signal(&privateVideoThreadEvent);
 	}
 }


### PR DESCRIPTION
I propose adding the `SDL_SYNCDRAW` flag to enable applications to make use of the `C3D_FRAME_SYNCDRAW` option when drawing frames on the video thread.

This resolves #75